### PR TITLE
Change how head element is found

### DIFF
--- a/addon/components/in-head.js
+++ b/addon/components/in-head.js
@@ -12,6 +12,8 @@ export default Component.extend({
     while (child) {
       if (child.tagName === 'HEAD') {
         return child;
+      } else {
+        return child.nextSibling;
       }
     }
   })

--- a/tests/integration/components/in-head-test.js
+++ b/tests/integration/components/in-head-test.js
@@ -12,6 +12,14 @@ module('Integration | Component | in head', function(hooks) {
     assert.ok(document.querySelector('meta[property="yes"]'), "should find our meta");
   });
 
+  test('it adds content to head when an invalid element has been added before it', async function(assert) {
+    assert.expect(1);
+    // The spec says head should always be the first child but Ronin Wallet inserts its script before head
+    document.documentElement.prepend(document.createElement('script'));
+    await render(hbs`{{#in-head}}<meta property="yes" content="it-works">{{/in-head}}`);
+    assert.ok(document.querySelector('meta[property="yes"]'), "should find our meta");
+  });
+
   test('it removes content from head', async function(assert) {
     assert.expect(1);
     this.set('showIt', true);


### PR DESCRIPTION
Hey, we received a report that particular pages ([this](https://wallet-staging.stack.cards/pay/sokol/0xA458a7C13B33188b4F71aA47A1067f651284361E?amount=1&currency=CAD) for example) were getting stuck in a rendering loop when the [Ronin Wallet extension](https://chrome.google.com/webstore/detail/ronin-wallet/fnjhmkhhmkbjkkabndcnnogagogbneec) was installed. I tracked this down to the application’s use of `InHead`, which internally searches for the `head` element starting at `document.firstChild`.

It turns out that Ronin Wallet inserts its `script` before `head`, despite [this being a spec violation](https://html.spec.whatwg.org/multipage/semantics.html#the-head-element):

<img width="860" alt="Cardstack 2022-06-24 14-15-42" src="https://user-images.githubusercontent.com/43280/175670945-a7f1f715-c82e-4651-9901-52ed25032881.png">

`firstChild` works to return the `head` element when Ronin Wallet is not installed:

<img width="260" alt="New Tab 2022-06-24 14-19-21" src="https://user-images.githubusercontent.com/43280/175679654-352b0e70-64a4-4596-b91d-2a4828c7f870.png">

I tried `document.head` successfully in a PR but it caused tests to fail, I don’t know why. `querySelector('head')` works with the tests though. The [PR](https://github.com/cardstack/cardstack/pull/3050/files#diff-fd9593f6c130f3c7d081b6dfb34f9797d033281ad9d5e889cae0ab1f205778edR11)’s preview deployment completed rendering as expected with Ronin Wallet installed.

The existing implementation’s use of `while` suggests to me maybe a depth-first search was intended, but since `child` was never mutated, it was just stuck in a loop.